### PR TITLE
Updates the Docker version and adds a task to check for existing docker install

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -170,7 +170,7 @@ docker_users: []
 
 # Define Docker version to install
 # 1.11.0|1.11.1|1.11.2|1.12.0|1.12.1|1.12.2|1.12.3|1.12.4|1.12.5|1.12.6|1.13.0|1.13.1
-# 17.03.0|17.03.1|17.03.2|17.04.0|17.05.0|17.06.0
+# 17.03.0|17.03.1|17.03.2|17.04.0|17.05.0|17.06.0|17.12.0
 # Currently as of 06/03/2017 17.04.0 and 17.05.0 must be installed from the
 # edge channel. Change docker_release_channel: 'edge'
-docker_version: 17.06.0
+docker_version: 17.12.0

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -64,11 +64,17 @@
         ansible_distribution == "Ubuntu" and
         (ansible_distribution_version >= '14.04')
 
+- name: debian | checking for existing docker
+  shell: dpkg-query -W 'docker-ce'
+  ignore_errors: true
+  register: has_docker
+
 - name: debian | installing docker
   apt:
     name: "docker-ce={{ docker_version_debian }}"
     state: "present"
   become: true
+  when: has_docker|failed
 
 - name: debian | setting grub memory limit (if set)
   lineinfile:

--- a/tasks/set_facts.yml
+++ b/tasks/set_facts.yml
@@ -27,7 +27,15 @@
     docker_version_debian: '{{ docker_version }}~ce-0~{{ ansible_distribution|lower }}'
   when: >
         ansible_os_family == "Debian" and
-        (docker_version >= '17.06')
+        (docker_version >= '17.06' and
+        docker_version < '17.09')
+
+- name: set_facts | Setting Docker Version To Install (Debian)
+  set_fact:
+    docker_version_debian: '{{ docker_version }}~ce-0~{{ ansible_distribution|lower }}'
+  when: >
+        ansible_os_family == "Debian" and
+        (docker_version >= '17.09')
 
 - name: set_facts | Setting Docker Version To Install (Fedora)
   set_fact:


### PR DESCRIPTION
This pull addresses two problems encountered:

- Install would fail if docker was already installed
- docker version was out of date on 16.04 systems

Changes:
defaults/main.yml - Bumped version to 17.12.0
tasks/set_facts.yml - Added version clause for versions >- 17.09
tasks/debian.yml - Add has_docker variable and check for existing Docker install"